### PR TITLE
Added event.preventDefault() on click event to avoid /# at the end of url

### DIFF
--- a/app/templates/public/app.js
+++ b/app/templates/public/app.js
@@ -1,9 +1,11 @@
-document.addEventListener("DOMContentLoaded", function(event) { 
-  document.getElementById('signin-button').addEventListener('click', function() {
+document.addEventListener("DOMContentLoaded", function(event) {
+  document.getElementById('signin-button').addEventListener('click', function(event) {
+    event.preventDefault()
     var authRequest = blockstack.makeAuthRequest(null, window.location.origin)
     blockstack.redirectUserToSignIn(authRequest)
   })
-  document.getElementById('signout-button').addEventListener('click', function() {
+  document.getElementById('signout-button').addEventListener('click', function(event) {
+    event.preventDefault()
     blockstack.signUserOut(window.location.origin)
   })
 


### PR DESCRIPTION
Should prevent default for `<a href="#">` click events which is to add the `#` at the end of the url.