### PR TITLE
Fix package.json npm start script on Windows

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "browserify": "browserify requires.js -o public/bundle.js",
-    "start": "npm run browserify; node server.js"
+    "start": "npm run browserify && node server.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Use a cross platform `&&` for running multiple commands.