### PR TITLE
Added @blockstack/connect lib to react package.json

### DIFF
--- a/react/templates/_package.json
+++ b/react/templates/_package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "blockstack": "^19.2.5",
+    "@blockstack/connect": "^2.7.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-router-dom": "^4.3.1",

--- a/react/templates/_package.json
+++ b/react/templates/_package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "blockstack": "^19.2.5",
-    "@blockstack/connect": "^2.7.1",
+    "@blockstack/connect": "^2.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-router-dom": "^4.3.1",


### PR DESCRIPTION
## Steps to reproduce
1. Run `npx generator-blockstack --react`
2. Run `npm run start`
3. Server fails to compile as `Module not found: Can't resolve '@blockstack/connect' in src/App.js`

## Changes
1. Just added the latest `@blockstack/connect` to `package.json` which should fix this issue.